### PR TITLE
初期化時のトレースポイントにトレースフィルタリングの適用

### DIFF
--- a/include/caret_trace/tp.h
+++ b/include/caret_trace/tp.h
@@ -102,6 +102,21 @@ TRACEPOINT_EVENT(
 
 TRACEPOINT_EVENT(
   TRACEPOINT_PROVIDER,
+  construct_static_executor,
+  TP_ARGS(
+    const void *, executor_addr_arg,
+    const void *, entities_collector_addr_arg,
+    const char *, executor_type_name_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, executor_addr, executor_addr_arg)
+    ctf_integer_hex(const void *, entities_collector_addr, entities_collector_addr_arg)
+    ctf_string(executor_type_name, executor_type_name_arg)
+  )
+)
+
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
   add_callback_group,
   TP_ARGS(
     const void *, executor_addr_arg,
@@ -110,6 +125,21 @@ TRACEPOINT_EVENT(
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, executor_addr, executor_addr_arg)
+    ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
+    ctf_string(group_type_name, group_type_name_arg)
+  )
+)
+
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  add_callback_group_static_executor,
+  TP_ARGS(
+    const void *, entities_collector_addr_arg,
+    const void *, callback_group_addr_arg,
+    const char *, group_type_name_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, entities_collector_addr, entities_collector_addr_arg)
     ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
     ctf_string(group_type_name, group_type_name_arg)
   )

--- a/include/caret_trace/tp.h
+++ b/include/caret_trace/tp.h
@@ -92,11 +92,11 @@ TRACEPOINT_EVENT(
   construct_executor,
   TP_ARGS(
     const void *, executor_addr_arg,
-    const char *, executor_name_arg
+    const char *, executor_type_name_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, executor_addr, executor_addr_arg)
-    ctf_string(executor_name, executor_name_arg)
+    ctf_string(executor_type_name, executor_type_name_arg)
   )
 )
 

--- a/include/caret_trace/tp.h
+++ b/include/caret_trace/tp.h
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Provide fake header guard for cpplint
+#undef CARET_TRACE__TP_H_
+#ifndef CARET_TRACE__TP_H_
+#define CARET_TRACE__TP_H_
+
 #undef TRACEPOINT_PROVIDER
 #define TRACEPOINT_PROVIDER ros2_caret
 
@@ -85,3 +90,5 @@ TRACEPOINT_EVENT(
 #endif /* _TP_H */
 
 #include <lttng/tracepoint-event.h>
+
+#endif  // CARET_TRACE__TP_H_

--- a/include/caret_trace/tp.h
+++ b/include/caret_trace/tp.h
@@ -87,6 +87,84 @@ TRACEPOINT_EVENT(
   )
 )
 
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  construct_executor,
+  TP_ARGS(
+    const void *, executor_addr_arg,
+    const char *, executor_name_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, executor_addr, executor_addr_arg)
+    ctf_string(executor_name, executor_name_arg)
+  )
+)
+
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  add_callback_group,
+  TP_ARGS(
+    const void *, executor_addr_arg,
+    const void *, callback_group_addr_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, executor_addr, executor_addr_arg)
+    ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
+  )
+)
+
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  callback_group_add_timer,
+  TP_ARGS(
+    const void *, callback_group_addr_arg,
+    const void *, timer_handle_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
+    ctf_integer_hex(const void *, timer_handle, timer_handle_arg)
+  )
+)
+
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  callback_group_add_subscription,
+  TP_ARGS(
+    const void *, callback_group_addr_arg,
+    const void *, subscription_handle_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
+    ctf_integer_hex(const void *, subscription_handle, subscription_handle_arg)
+  )
+)
+
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  callback_group_add_service,
+  TP_ARGS(
+    const void *, callback_group_addr_arg,
+    const void *, service_handle_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
+    ctf_integer_hex(const void *, service_handle, service_handle_arg)
+  )
+)
+
+TRACEPOINT_EVENT(
+  TRACEPOINT_PROVIDER,
+  callback_group_add_client,
+  TP_ARGS(
+    const void *, callback_group_addr_arg,
+    const void *, client_handle_arg
+  ),
+  TP_FIELDS(
+    ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
+    ctf_integer_hex(const void *, client_handle, client_handle_arg)
+  )
+)
+
 #endif /* _TP_H */
 
 #include <lttng/tracepoint-event.h>

--- a/include/caret_trace/tp.h
+++ b/include/caret_trace/tp.h
@@ -105,11 +105,13 @@ TRACEPOINT_EVENT(
   add_callback_group,
   TP_ARGS(
     const void *, executor_addr_arg,
-    const void *, callback_group_addr_arg
+    const void *, callback_group_addr_arg,
+    const char *, group_type_name_arg
   ),
   TP_FIELDS(
     ctf_integer_hex(const void *, executor_addr, executor_addr_arg)
     ctf_integer_hex(const void *, callback_group_addr, callback_group_addr_arg)
+    ctf_string(group_type_name, group_type_name_arg)
   )
 )
 

--- a/include/caret_trace/tracing_controller.hpp
+++ b/include/caret_trace/tracing_controller.hpp
@@ -35,7 +35,7 @@ public:
     const void * subscription, const void * callback);
 
   void add_timer_handle(
-    const void * node_handle, const void * client_handle);
+    const void * node_handle, const void * timer_handle);
 
   void add_timer_callback(
     const void * timer_handle, const void * callback);

--- a/include/caret_trace/tracing_controller.hpp
+++ b/include/caret_trace/tracing_controller.hpp
@@ -37,10 +37,19 @@ public:
   void add_timer_handle(
     const void * node_handle, const void * timer_handle);
 
+  void add_publisher_handle(
+    const void * node_handle, const void * publisher_handle, std::string topic_name);
+
   void add_timer_callback(
     const void * timer_handle, const void * callback);
 
   bool is_allowed_callback(const void * callback);
+
+  bool is_allowed_node(const void * node_handle);
+
+  bool is_allowed_publisher_handle(const void * publisher_handle);
+
+  bool is_allowed_subscription_handle(const void * subscription_handle);
 
 private:
   std::shared_timed_mutex mutex_;
@@ -64,6 +73,10 @@ private:
   std::unordered_map<const void *, const void *> callback_to_timer_handles_;
   std::unordered_map<const void *, const void *> timer_handle_to_node_handles_;
   std::unordered_map<const void *, bool> allowed_callbacks_;
+
+  std::unordered_map<const void *, const void *> publisher_handle_to_node_handles_;
+  std::unordered_map<const void *, std::string> publisher_handle_to_topic_names_;
+  std::unordered_map<const void *, bool> allowed_publishers_;
 };
 
 #endif  // CARET_TRACE__TRACING_CONTROLLER_HPP_

--- a/include/caret_trace/tracing_controller.hpp
+++ b/include/caret_trace/tracing_controller.hpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef CARET_TRACER__TRACING_CONTROLLER_HPP_
+#ifndef CARET_TRACE__TRACING_CONTROLLER_HPP_
 
 #include <shared_mutex>
 #include <unordered_set>
@@ -66,5 +66,5 @@ private:
   std::unordered_map<const void *, bool> allowed_callbacks_;
 };
 
-#endif  // CARET_TRACER__TRACING_CONTROLLER_HPP_
-#define CARET_TRACER__TRACING_CONTROLLER_HPP_
+#endif  // CARET_TRACE__TRACING_CONTROLLER_HPP_
+#define CARET_TRACE__TRACING_CONTROLLER_HPP_

--- a/src/hooked_trace_points.cpp
+++ b/src/hooked_trace_points.cpp
@@ -154,7 +154,7 @@ public:
   spin_once_impl(std::chrono::nanoseconds timeout) override;
 
 // private:
-  // RCLCPP_DISABLE_COPY(StaticSingleThreadedExecutor)
+// RCLCPP_DISABLE_COPY(StaticSingleThreadedExecutor)
 
   StaticExecutorEntitiesCollector::SharedPtr entities_collector_;
 };
@@ -596,11 +596,11 @@ void SYMBOL_CONCAT_3(
     const void *,
     bool);
   auto group_addr = static_cast<const void *>(group_ptr.get());
-  std::string  group_type_name = "unknown";
+  std::string group_type_name = "unknown";
   auto group_type = group_ptr->type();
-  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive){
+  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive) {
     group_type_name = "mutually_exclusive";
-  } else if (group_type == rclcpp::CallbackGroupType::Reentrant){
+  } else if (group_type == rclcpp::CallbackGroupType::Reentrant) {
     group_type_name = "reentrant";
   }
 
@@ -617,10 +617,10 @@ bool SYMBOL_CONCAT_3(
   _ZN6rclcpp9executors31StaticExecutorEntitiesCollector18add_callback_groupESt10shared_ptr,
   INS_13CallbackGroupEES2_INS_15node_interfaces17NodeBaseInterface,
   EERSt3mapISt8weak_ptrIS3_ES9_IS6_ESt10owner_lessISA_ESaISt4pairIKSA_SB_EEE) (
-    void * obj,
-    rclcpp::CallbackGroup::SharedPtr group_ptr,
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
-    rclcpp::memory_strategy::MemoryStrategy::WeakCallbackGroupsToNodesMap & weak_groups_to_nodes)
+  void * obj,
+  rclcpp::CallbackGroup::SharedPtr group_ptr,
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+  rclcpp::memory_strategy::MemoryStrategy::WeakCallbackGroupsToNodesMap & weak_groups_to_nodes)
 {
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
   using functionT = bool (*)(
@@ -630,17 +630,18 @@ bool SYMBOL_CONCAT_3(
     rclcpp::memory_strategy::MemoryStrategy::WeakCallbackGroupsToNodesMap &);
 
   auto group_addr = static_cast<const void *>(group_ptr.get());
-  std::string  group_type_name = "unknown";
+  std::string group_type_name = "unknown";
   auto group_type = group_ptr->type();
-  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive){
+  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive) {
     group_type_name = "mutually_exclusive";
-  } else if (group_type == rclcpp::CallbackGroupType::Reentrant){
+  } else if (group_type == rclcpp::CallbackGroupType::Reentrant) {
     group_type_name = "reentrant";
   }
 
   auto ret = ((functionT) orig_func)(obj, group_ptr, node_ptr, weak_groups_to_nodes);
 
-  tracepoint(TRACEPOINT_PROVIDER, add_callback_group_static_executor,
+  tracepoint(
+    TRACEPOINT_PROVIDER, add_callback_group_static_executor,
     obj, group_addr, group_type_name.c_str());
 #ifdef DEBUG_OUTPUT
   std::cerr << "add_callback_group_static_executor," << obj << "," << group_addr << "," <<

--- a/src/hooked_trace_points.cpp
+++ b/src/hooked_trace_points.cpp
@@ -47,6 +47,9 @@
 // for cyclonedds
 #include "dds/dds.h"
 
+#define SYMBOL_CONCAT_2(x, y)  x ## y
+#define SYMBOL_CONCAT_3(x, y, z)  x ## y ## z
+
 
 // Declare a prototype in order to use the functions implemented in cyclonedds.
 rmw_ret_t rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid);
@@ -313,8 +316,9 @@ bool _ZN8eprosima7fastdds3dds10DataWriter5writeEPvRNS_8fastrtps4rtps11WriteParam
 // The bind from &payload to source_timestamp is done by unsent_change_added_to_history.
 // bind: &ros_message -> &payload
 // rmw_fastrtps_shared_cpp::TypeSupport::serialize(void*, eprosima::fastrtps::rtps::SerializedPayload_t*)   // NOLINT
-bool
-_ZN23rmw_fastrtps_shared_cpp11TypeSupport9serializeEPvPN8eprosima8fastrtps4rtps19SerializedPayload_tE(
+bool SYMBOL_CONCAT_2(
+  _ZN23rmw_fastrtps_shared_cpp11TypeSupport9serialize,
+  EPvPN8eprosima8fastrtps4rtps19SerializedPayload_tE)(
   // NOLINT
   void * obj, void * data, eprosima::fastrtps::rtps::SerializedPayload_t * payload)
 {
@@ -338,13 +342,15 @@ _ZN23rmw_fastrtps_shared_cpp11TypeSupport9serializeEPvPN8eprosima8fastrtps4rtps1
 // for fastrtps
 // bind: &payload -> source_timestamp
 // unsent_change_added_to_history
-void
-_ZN8eprosima8fastrtps4rtps15StatelessWriter30unsent_change_added_to_historyEPNS1_13CacheChange_tERKNSt6chrono10time_pointINS5_3_V212steady_clockENS5_8durationIlSt5ratioILl1ELl1000000000EEEEEE(
+void SYMBOL_CONCAT_3(
+  _ZN8eprosima8fastrtps4rtps15StatelessWriter30unsent_change_added_to_history,
+  EPNS1_13CacheChange_tERKNSt6chrono10time_point,
+  INS5_3_V212steady_clockENS5_8durationIlSt5ratioILl1ELl1000000000EEEEEE)(
   // NOLINT
   void * obj,
   eprosima::fastrtps::rtps::CacheChange_t * change,
-  const std::chrono::time_point<std::chrono::steady_clock> & max_blocking_time
-)
+  const std::chrono::time_point<std::chrono::steady_clock>&max_blocking_time
+  )
 {
   using functionT = bool (*)(
     void *,
@@ -368,13 +374,15 @@ _ZN8eprosima8fastrtps4rtps15StatelessWriter30unsent_change_added_to_historyEPNS1
 // for fastrtps
 // bind: &payload -> source_timestamp
 // unsent_change_added_to_history
-void
-_ZN8eprosima8fastrtps4rtps14StatefulWriter30unsent_change_added_to_historyEPNS1_13CacheChange_tERKNSt6chrono10time_pointINS5_3_V212steady_clockENS5_8durationIlSt5ratioILl1ELl1000000000EEEEEE(
+void SYMBOL_CONCAT_3(
+  _ZN8eprosima8fastrtps4rtps14StatefulWriter30unsent_change_added_to_history,
+  EPNS1_13CacheChange_tERKNSt6chrono10time_point,
+  INS5_3_V212steady_clockENS5_8durationIlSt5ratioILl1ELl1000000000EEEEEE)(
   // NOLINT
   void * obj,
   eprosima::fastrtps::rtps::CacheChange_t * change,
-  const std::chrono::time_point<std::chrono::steady_clock> & max_blocking_time
-)
+  const std::chrono::time_point<std::chrono::steady_clock>&max_blocking_time
+  )
 {
   using functionT =
     bool (*)(

--- a/src/hooked_trace_points.cpp
+++ b/src/hooked_trace_points.cpp
@@ -401,4 +401,177 @@ void SYMBOL_CONCAT_3(
     std::endl;
 #endif
 }
+
+// rclcpp::executors::SingleThreadedExecutor::SingleThreadedExecutor(rclcpp::ExecutorOptions const&)
+void _ZN6rclcpp9executors22SingleThreadedExecutorC1ERKNS_15ExecutorOptionsE(
+  void * obj,
+  const void * option)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(void *, const void *);
+  ((functionT) orig_func)(obj, option);
+
+  tracepoint(TRACEPOINT_PROVIDER, construct_executor, obj, "single_threaded_executor");
+#ifdef DEBUG_OUTPUT
+  std::cerr << "construct_executor," <<
+    "single_threaded_executor" << "," <<
+    obj << std::endl;
+#endif
+}
+
+// rclcpp::executors::MultiThreadedExecutor::MultiThreadedExecutor(
+// rclcpp::ExecutorOptions const&, unsigned long, bool,
+// std::chrono::duration<long, std::ratio<1l, 1000000000l> >)
+void
+SYMBOL_CONCAT_2(
+  _ZN6rclcpp9executors21MultiThreadedExecutor,
+  C1ERKNS_15ExecutorOptionsEmbNSt6chrono8durationIlSt5ratioILl1ELl1000000000EEEE)(
+  void * obj,
+  const void * option,
+  size_t number_of_thread,
+  bool yield_before_execute,
+  const void * timeout)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(void *, const void *, size_t, bool, const void *);
+  ((functionT) orig_func)(obj, option, number_of_thread, yield_before_execute, timeout);
+
+  tracepoint(TRACEPOINT_PROVIDER, construct_executor, obj, "multi_threaded_executor");
+#ifdef DEBUG_OUTPUT
+  std::cerr << "construct_executor," <<
+    "multi_threaded_executor" << "," <<
+    obj << std::endl;
+#endif
+}
+
+// rclcpp::executors::StaticSingleThreadedExecutor::StaticSingleThreadedExecutor(
+// rclcpp::ExecutorOptions const&)
+void _ZN6rclcpp9executors28StaticSingleThreadedExecutorC1ERKNS_15ExecutorOptionsE(
+  void * obj,
+  const void * option)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(void *, const void *);
+  ((functionT) orig_func)(obj, option);
+
+  tracepoint(TRACEPOINT_PROVIDER, construct_executor, obj, "static_single_threaded_executor");
+#ifdef DEBUG_OUTPUT
+  std::cerr << "construct_executor," <<
+    "static_single_threaded_executor" << "," <<
+    obj << std::endl;
+#endif
+}
+
+// rclcpp::Executor::add_callback_group_to_map(
+//   std::shared_ptr<rclcpp::CallbackGroup>,
+//   std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>,
+//   std::map<std::weak_ptr<rclcpp::CallbackGroup>,
+//   std::weak_ptr<rclcpp::node_interfaces::NodeBaseInterface>,
+//   std::owner_less<std::weak_ptr<rclcpp::CallbackGroup> >,
+//   std::allocator<std::pair<std::weak_ptr<rclcpp::CallbackGroup> const,
+//   std::weak_ptr<rclcpp::node_interfaces::NodeBaseInterface> > > >&,
+//   bool)
+void SYMBOL_CONCAT_3(
+  _ZN6rclcpp8Executor25add_callback_group_to_map,
+  ESt10shared_ptrINS_13CallbackGroupEES1_INS_15node_interfaces17NodeBaseInterface,
+  EERSt3mapISt8weak_ptrIS2_ES8_IS5_ESt10owner_lessIS9_ESaISt4pairIKS9_SA_EEEb)(
+  void * obj,
+  rclcpp::CallbackGroup::SharedPtr group_ptr,
+  const void * node_ptr,
+  const void * weak_groups_to_nodes,
+  bool notify
+  )
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(
+    void *,
+    rclcpp::CallbackGroup::SharedPtr,
+    const void *,
+    const void *,
+    bool);
+  auto group_addr = static_cast<const void *>(group_ptr.get());
+
+  ((functionT) orig_func)(obj, group_ptr, node_ptr, weak_groups_to_nodes, notify);
+
+  tracepoint(TRACEPOINT_PROVIDER, add_callback_group, obj, group_addr);
+#ifdef DEBUG_OUTPUT
+  std::cerr << "add_callback_group," << obj << "," << group_addr <<
+    std::endl;
+#endif
+}
+
+//  rclcpp::CallbackGroup::add_timer(std::shared_ptr<rclcpp::TimerBase>)
+void _ZN6rclcpp13CallbackGroup9add_timerESt10shared_ptrINS_9TimerBaseEE(
+  // ok
+  void * obj,
+  const rclcpp::TimerBase::SharedPtr timer_ptr)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(void *, const rclcpp::TimerBase::SharedPtr);
+
+  auto timer_handle = static_cast<const void *>(timer_ptr->get_timer_handle().get());
+  ((functionT) orig_func)(obj, timer_ptr);
+
+  tracepoint(TRACEPOINT_PROVIDER, callback_group_add_timer, obj, timer_handle);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "callback_group_add_timer," << obj << "," << timer_handle << std::endl;
+#endif
+}
+
+// rclcpp::CallbackGroup::add_subscription(std::shared_ptr<rclcpp::SubscriptionBase>)
+void _ZN6rclcpp13CallbackGroup16add_subscriptionESt10shared_ptrINS_16SubscriptionBaseEE(
+  void * obj,
+  const rclcpp::SubscriptionBase::SharedPtr subscription_ptr
+)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(void *, const rclcpp::SubscriptionBase::SharedPtr);
+
+  auto subscription_handle = static_cast<const void *>(
+    subscription_ptr->get_subscription_handle().get());
+  ((functionT) orig_func)(obj, subscription_ptr);
+
+  tracepoint(TRACEPOINT_PROVIDER, callback_group_add_subscription, obj, subscription_handle);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "callback_group_add_subscription," << obj << "," << subscription_handle << std::endl;
+#endif
+}
+
+// rclcpp::CallbackGroup::add_service(std::shared_ptr<rclcpp::ServiceBase>)
+void _ZN6rclcpp13CallbackGroup11add_serviceESt10shared_ptrINS_11ServiceBaseEE(
+  void * obj,
+  const rclcpp::ServiceBase::SharedPtr service_ptr)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(void *, const rclcpp::ServiceBase::SharedPtr);
+
+  auto service_handle = static_cast<const void *>(service_ptr->get_service_handle().get());
+  ((functionT) orig_func)(obj, service_ptr);
+
+  tracepoint(TRACEPOINT_PROVIDER, callback_group_add_service, obj, service_handle);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "callback_group_add_service," << obj << "," << service_handle << std::endl;
+#endif
+}
+
+// rclcpp::CallbackGroup::add_client(std::shared_ptr<rclcpp::ClientBase>)
+void _ZN6rclcpp13CallbackGroup10add_clientESt10shared_ptrINS_10ClientBaseEE(
+  void * obj,
+  const rclcpp::ClientBase::SharedPtr client_ptr)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(void *, const rclcpp::ClientBase::SharedPtr);
+
+  auto client_handle = static_cast<const void *>(client_ptr->get_client_handle().get());
+  ((functionT) orig_func)(obj, client_ptr);
+
+  tracepoint(TRACEPOINT_PROVIDER, callback_group_add_client, obj, client_handle);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "callback_group_add_client," << obj << "," << client_handle << std::endl;
+#endif
+}
 }

--- a/src/hooked_trace_points.cpp
+++ b/src/hooked_trace_points.cpp
@@ -490,13 +490,20 @@ void SYMBOL_CONCAT_3(
     const void *,
     bool);
   auto group_addr = static_cast<const void *>(group_ptr.get());
+  std::string  group_type_name = "unknown";
+  auto group_type = group_ptr->type();
+  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive){
+    group_type_name = "mutually_exclusive";
+  } else if (group_type == rclcpp::CallbackGroupType::Reentrant){
+    group_type_name = "reentrant";
+  }
 
   ((functionT) orig_func)(obj, group_ptr, node_ptr, weak_groups_to_nodes, notify);
 
-  tracepoint(TRACEPOINT_PROVIDER, add_callback_group, obj, group_addr);
+  tracepoint(TRACEPOINT_PROVIDER, add_callback_group, obj, group_addr, group_type_name.c_str());
 #ifdef DEBUG_OUTPUT
-  std::cerr << "add_callback_group," << obj << "," << group_addr <<
-    std::endl;
+  std::cerr << "add_callback_group," << obj << "," << group_addr << "," <<
+    group_type_name << std::endl;
 #endif
 }
 

--- a/src/hooked_trace_points.cpp
+++ b/src/hooked_trace_points.cpp
@@ -410,11 +410,12 @@ void _ZN6rclcpp9executors22SingleThreadedExecutorC1ERKNS_15ExecutorOptionsE(
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
   using functionT = void (*)(void *, const void *);
   ((functionT) orig_func)(obj, option);
+  const std::string executor_type_name = "single_threaded_executor";
 
-  tracepoint(TRACEPOINT_PROVIDER, construct_executor, obj, "single_threaded_executor");
+  tracepoint(TRACEPOINT_PROVIDER, construct_executor, obj, executor_type_name.c_str());
 #ifdef DEBUG_OUTPUT
   std::cerr << "construct_executor," <<
-    "single_threaded_executor" << "," <<
+    executor_type_name << "," <<
     obj << std::endl;
 #endif
 }
@@ -435,11 +436,12 @@ SYMBOL_CONCAT_2(
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
   using functionT = void (*)(void *, const void *, size_t, bool, const void *);
   ((functionT) orig_func)(obj, option, number_of_thread, yield_before_execute, timeout);
+  const std::string executor_type_name = "single_threaded_executor";
 
-  tracepoint(TRACEPOINT_PROVIDER, construct_executor, obj, "multi_threaded_executor");
+  tracepoint(TRACEPOINT_PROVIDER, construct_executor, obj, executor_type_name.c_str());
 #ifdef DEBUG_OUTPUT
   std::cerr << "construct_executor," <<
-    "multi_threaded_executor" << "," <<
+    executor_type_name << "," <<
     obj << std::endl;
 #endif
 }

--- a/src/ros_trace_points.cpp
+++ b/src/ros_trace_points.cpp
@@ -192,72 +192,80 @@ void ros_trace_callback_end(const void * callback)
 void ros_trace_dispatch_subscription_callback(
   const void * message,
   const void * callback,
-  const uint64_t source_timestamp)
+  const uint64_t source_timestamp,
+  const uint64_t message_timestamp)
 {
   static auto & controller = Singleton<TracingController>::get_instance();
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
 
-  using functionT = void (*)(const void *, const void *, const uint64_t);
+  using functionT = void (*)(const void *, const void *, const uint64_t, const uint64_t);
   if (controller.is_allowed_callback(callback)) {
-    ((functionT) orig_func)(message, callback, source_timestamp);
+    ((functionT) orig_func)(message, callback, source_timestamp, message_timestamp);
   }
 
 #ifdef DEBUG_OUTPUT
   std::cerr << "dispatch_subscription_callback," <<
     message << "," <<
     callback << "," <<
-    source_timestamp << std::endl;
+    source_timestamp << "," <<
+    message_timestamp << std::endl;
 #endif
 }
 
 void ros_trace_dispatch_intra_process_subscription_callback(
   const void * message,
-  const void * callback)
+  const void * callback,
+  const uint64_t message_timestamp)
 {
   static auto & controller = Singleton<TracingController>::get_instance();
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
 
-  using functionT = void (*)(const void *, const void *);
+  using functionT = void (*)(const void *, const void *, const uint64_t);
   if (controller.is_allowed_callback(callback)) {
-    ((functionT) orig_func)(message, callback);
+    ((functionT) orig_func)(message, callback, message_timestamp);
   }
 
 #ifdef DEBUG_OUTPUT
   std::cerr << "dispatch_intra_process_subscription_callback," <<
     message << "," <<
-    callback << std::endl;
+    callback << "," <<
+    message_timestamp << std::endl;
 #endif
 }
 
 #ifdef DEBUG_OUTPUT
 void ros_trace_rclcpp_publish(
   const void * publisher_handle,
-  const void * message)
+  const void * message,
+  const uint64_t message_timestamp)
 {
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
 
-  using functionT = void (*)(const void *, const void *);
-  ((functionT) orig_func)(publisher_handle, message);
+  using functionT = void (*)(const void *, const void *, const uint64_t);
+  ((functionT) orig_func)(publisher_handle, message, message_timestamp);
 
   std::cerr << "rclcpp_publish," <<
     publisher_handle << "," <<
-    message << std::endl;
+    message << "," <<
+    message_timestamp << std::endl;
 }
 #endif
 
 #ifdef DEBUG_OUTPUT
 void ros_trace_rclcpp_intra_publish(
   const void * publisher_handle,
-  const void * message)
+  const void * message,
+  const uint64_t message_timestamp)
 {
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
 
-  using functionT = void (*)(const void *, const void *);
-  ((functionT) orig_func)(publisher_handle, message);
+  using functionT = void (*)(const void *, const void *, const uint64_t message_timestamp);
+  ((functionT) orig_func)(publisher_handle, message, message_timestamp);
 
   std::cerr << "rclcpp_intra_publish," <<
     publisher_handle << "," <<
-    message << std::endl;
+    message << "," <<
+    message_timestamp << std::endl;
 }
 #endif
 

--- a/src/ros_trace_points.cpp
+++ b/src/ros_trace_points.cpp
@@ -22,6 +22,8 @@
 #include "caret_trace/tracing_controller.hpp"
 #include "caret_trace/singleton.hpp"
 
+// #define DEBUG_OUTPUT
+
 extern "C" {
 void ros_trace_rcl_node_init(
   const void * node_handle,
@@ -43,6 +45,14 @@ void ros_trace_rcl_node_init(
 
   using functionT = void (*)(const void *, const void *, const char *, const char *);
   ((functionT) orig_func)(node_handle, rmw_handle, node_name, node_namespace);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "rcl_node_init," <<
+    node_handle << "," <<
+    rmw_handle << "," <<
+    node_name << "," <<
+    node_namespace << std::endl;
+#endif
 }
 
 void ros_trace_rcl_subscription_init(
@@ -62,6 +72,15 @@ void ros_trace_rcl_subscription_init(
   ((functionT) orig_func)(
     subscription_handle, node_handle, rmw_subscription_handle, topic_name,
     queue_depth);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "rcl_subscription_init," <<
+    subscription_handle << "," <<
+    node_handle << "," <<
+    rmw_subscription_handle << "," <<
+    topic_name << "," <<
+    queue_depth << std::endl;
+#endif
 }
 
 void ros_trace_rclcpp_subscription_init(
@@ -75,6 +94,12 @@ void ros_trace_rclcpp_subscription_init(
 
   using functionT = void (*)(const void *, const void *);
   ((functionT) orig_func)(subscription_handle, subscription);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "rclcpp_subscription_init," <<
+    subscription_handle << "," <<
+    subscription << std::endl;
+#endif
 }
 
 void ros_trace_rclcpp_subscription_callback_added(
@@ -88,6 +113,12 @@ void ros_trace_rclcpp_subscription_callback_added(
 
   using functionT = void (*)(const void *, const void *);
   ((functionT) orig_func)(subscription, callback);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "rclcpp_subscription_callback_added," <<
+    subscription << "," <<
+    callback << std::endl;
+#endif
 }
 
 void ros_trace_rclcpp_timer_callback_added(const void * timer_handle, const void * callback)
@@ -99,6 +130,12 @@ void ros_trace_rclcpp_timer_callback_added(const void * timer_handle, const void
 
   using functionT = void (*)(const void *, const void *);
   ((functionT) orig_func)(timer_handle, callback);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "rclcpp_timer_callback_added," <<
+    timer_handle << "," <<
+    callback << std::endl;
+#endif
 }
 
 void ros_trace_rclcpp_timer_link_node(const void * timer_handle, const void * node_handle)
@@ -110,6 +147,12 @@ void ros_trace_rclcpp_timer_link_node(const void * timer_handle, const void * no
 
   using functionT = void (*)(const void *, const void *);
   ((functionT) orig_func)(timer_handle, node_handle);
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "rclcpp_timer_link_node," <<
+    timer_handle << "," <<
+    node_handle << std::endl;
+#endif
 }
 
 void ros_trace_callback_start(const void * callback, bool is_intra_process)
@@ -122,6 +165,12 @@ void ros_trace_callback_start(const void * callback, bool is_intra_process)
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(callback, is_intra_process);
   }
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "callback_start," <<
+    callback << "," <<
+    is_intra_process << std::endl;
+#endif
 }
 
 void ros_trace_callback_end(const void * callback)
@@ -133,6 +182,11 @@ void ros_trace_callback_end(const void * callback)
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(callback);
   }
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "callback_end," <<
+    callback << std::endl;
+#endif
 }
 
 void ros_trace_dispatch_subscription_callback(
@@ -147,6 +201,13 @@ void ros_trace_dispatch_subscription_callback(
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(message, callback, source_timestamp);
   }
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "dispatch_subscription_callback," <<
+    message << "," <<
+    callback << "," <<
+    source_timestamp << std::endl;
+#endif
 }
 
 void ros_trace_dispatch_intra_process_subscription_callback(
@@ -160,5 +221,228 @@ void ros_trace_dispatch_intra_process_subscription_callback(
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(message, callback);
   }
+
+#ifdef DEBUG_OUTPUT
+  std::cerr << "dispatch_intra_process_subscription_callback," <<
+    message << "," <<
+    callback << std::endl;
+#endif
 }
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rclcpp_publish(
+  const void * publisher_handle,
+  const void * message)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+
+  using functionT = void (*)(const void *, const void *);
+  ((functionT) orig_func)(publisher_handle, message);
+
+  std::cerr << "rclcpp_publish," <<
+    publisher_handle << "," <<
+    message << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rclcpp_intra_publish(
+  const void * publisher_handle,
+  const void * message)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+
+  using functionT = void (*)(const void *, const void *);
+  ((functionT) orig_func)(publisher_handle, message);
+
+  std::cerr << "rclcpp_intra_publish," <<
+    publisher_handle << "," <<
+    message << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_timer_init(
+  const void * timer_handle,
+  int64_t period)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, int64_t);
+  ((functionT) orig_func)(timer_handle, period);
+
+  std::cerr << "rcl_timer_init," <<
+    timer_handle << "," <<
+    period << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_init(
+  const void * context_handle)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *);
+  ((functionT) orig_func)(context_handle);
+
+  std::cerr << "rcl_init," <<
+    context_handle << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_publisher_init(
+  const void * publisher_handle,
+  const void * node_handle,
+  const void * rmw_publisher_handle,
+  const char * topic_name,
+  const size_t queue_depth
+)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const void *, const void *, const char *, const size_t);
+  ((functionT) orig_func)(
+    publisher_handle,
+    node_handle,
+    rmw_publisher_handle,
+    topic_name,
+    queue_depth);
+
+  std::cerr << "rcl_publisher_init," <<
+    publisher_handle << "," <<
+    node_handle << "," <<
+    rmw_publisher_handle << "," <<
+    topic_name << "," <<
+    queue_depth << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_publish(
+  const void * publisher_handle,
+  const void * message)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const void *);
+  ((functionT) orig_func)(publisher_handle, message);
+
+  std::cerr << "rcl_publish," <<
+    publisher_handle << "," <<
+    message << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_service_init(
+  const void * service_handle,
+  const void * node_handle,
+  const void * rmw_service_handle,
+  const char * service_name)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const void *, const void *, const char *);
+  ((functionT) orig_func)(service_handle, node_handle, rmw_service_handle, service_name);
+
+  std::cerr << "rcl_service_init," <<
+    service_handle << "," <<
+    node_handle << "," <<
+    rmw_service_handle << "," <<
+    service_name << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rclcpp_service_callback_added(
+  const void * service_handle,
+  const char * callback)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const void *);
+  ((functionT) orig_func)(service_handle, callback);
+
+  std::cerr << "rclcpp_service_callback_added," <<
+    service_handle << "," <<
+    callback << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_client_init(
+  const void * client_handle,
+  const void * node_handle,
+  const void * rmw_client_handle,
+  const char * service_name)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const void *, const void *, const char *);
+  ((functionT) orig_func)(client_handle, node_handle, rmw_client_handle, service_name);
+
+  std::cerr << "rcl_client_init," <<
+    client_handle << "," <<
+    node_handle << "," <<
+    rmw_client_handle << "," <<
+    service_name << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rclcpp_callback_register(
+  const void * callback,
+  const char * symbol)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const char *);
+  ((functionT) orig_func)(callback, symbol);
+
+  std::cerr << "rclcpp_callback_register," <<
+    callback << "," <<
+    symbol << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_lifecycle_state_machine_init(
+  const void * node_handle,
+  const void * state_machine)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const void *);
+  ((functionT) orig_func)(node_handle, state_machine);
+
+  std::cerr << "rcl_lifecycle_state_machine_init," <<
+    node_handle << "," <<
+    state_machine << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_rcl_lifecycle_transition(
+  const void * state_machine,
+  const char * start_label,
+  const char * goal_label)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const char *, const char *);
+  ((functionT) orig_func)(state_machine, start_label, goal_label);
+
+  std::cerr << "rcl_lifecycle_transition," <<
+    state_machine << "," <<
+    start_label << "," <<
+    goal_label << "," << std::endl;
+}
+#endif
+
+#ifdef DEBUG_OUTPUT
+void ros_trace_message_construct(
+  const void * original_message,
+  const void * constructed_message)
+{
+  static void * orig_func = dlsym(RTLD_NEXT, __func__);
+  using functionT = void (*)(const void *, const void *);
+  ((functionT) orig_func)(original_message, constructed_message);
+
+  std::cerr << "message_construct," <<
+    original_message << "," <<
+    constructed_message << std::endl;
+}
+#endif
 }

--- a/src/tracing_controller.cpp
+++ b/src/tracing_controller.cpp
@@ -177,31 +177,142 @@ bool TracingController::is_allowed_callback(const void * callback)
     auto topic_name = to_topic_name(callback);
 
     if (select_enabled_) {
-      auto is_selected_node = partial_match(selected_node_names_, node_name);
       auto is_selected_topic = partial_match(selected_topic_names_, topic_name);
-      if (is_selected_node || is_selected_topic) {
+      auto is_selected_node = partial_match(selected_node_names_, node_name);
+
+      if (selected_topic_names_.size() > 0 && is_selected_topic) {
         allowed_callbacks_.insert(std::make_pair(callback, true));
         return true;
-      } else {
-        allowed_callbacks_.insert(std::make_pair(callback, false));
-        return false;
       }
-    } else if (ignore_enabled_) {
+      if (selected_node_names_.size() > 0 && is_selected_node) {
+        allowed_callbacks_.insert(std::make_pair(callback, true));
+        return true;
+      }
+      if (selected_node_names_.size() == 0 && topic_name == "") { // allow timer callback
+        allowed_callbacks_.insert(std::make_pair(callback, true));
+        return true;
+      }
+
+      allowed_callbacks_.insert(std::make_pair(callback, false));
+      return false;
+    }
+    if (ignore_enabled_) {
       auto is_ignored_node = partial_match(ignored_node_names_, node_name);
       auto is_ignored_topic = partial_match(ignored_topic_names_, topic_name);
-      if (is_ignored_node || is_ignored_topic) {
+
+      if (ignored_node_names_.size() > 0 && is_ignored_node) {
         allowed_callbacks_.insert(std::make_pair(callback, false));
         return false;
-      } else {
-        allowed_callbacks_.insert(std::make_pair(callback, true));
-        return true;
       }
+      if (ignored_topic_names_.size() > 0 && is_ignored_topic) {
+        allowed_callbacks_.insert(std::make_pair(callback, false));
+        return false;
+      }
+      allowed_callbacks_.insert(std::make_pair(callback, true));
+      return true;
     }
     allowed_callbacks_.insert(std::make_pair(callback, true));
     return true;
   }
 }
 
+bool TracingController::is_allowed_node(const void * node_handle)
+{
+  std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+  auto node_name = node_handle_to_node_names_[node_handle];
+  if (select_enabled_ && selected_node_names_.size() > 0) {
+    auto is_selected_node = partial_match(selected_node_names_, node_name);
+    return is_selected_node;
+  } else if (ignore_enabled_ && ignored_node_names_.size() > 0) {
+    auto is_ignored_node = partial_match(ignored_node_names_, node_name);
+    return !is_ignored_node;
+  }
+  return true;
+}
+
+bool TracingController::is_allowed_subscription_handle(const void * subscription_handle)
+{
+  std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+  auto node_handle = subscription_handle_to_node_handles_[subscription_handle];
+  auto node_name = node_handle_to_node_names_[node_handle];
+  auto topic_name = subscription_handle_to_topic_names_[subscription_handle];
+
+  if (select_enabled_) {
+    auto is_selected_node = partial_match(selected_node_names_, node_name);
+    auto is_selected_topic = partial_match(selected_topic_names_, topic_name);
+
+    if (is_selected_node && selected_node_names_.size() > 0) {
+      return true;
+    }
+    if (is_selected_topic && selected_topic_names_.size() > 0) {
+      return true;
+    }
+    return false;
+  } else if (ignore_enabled_) {
+    auto is_ignored_node = partial_match(ignored_node_names_, node_name);
+    auto is_ignored_topic = partial_match(ignored_topic_names_, topic_name);
+
+    if (is_ignored_node && ignored_node_names_.size() > 0) {
+      return false;
+    }
+    if (is_ignored_topic && ignored_topic_names_.size() > 0) {
+      return false;
+    }
+    return true;
+  }
+  return true;
+}
+
+bool TracingController::is_allowed_publisher_handle(const void * publisher_handle)
+{
+  std::unordered_map<const void *, bool>::iterator is_allowed_it;
+  {
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    is_allowed_it = allowed_publishers_.find(publisher_handle);
+    if (is_allowed_it != allowed_publishers_.end() ) {
+      return is_allowed_it->second;
+    }
+  }
+  {
+    std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+    auto node_handle = publisher_handle_to_node_handles_[publisher_handle];
+    auto node_name = node_handle_to_node_names_[node_handle];
+    auto topic_name = publisher_handle_to_topic_names_[publisher_handle];
+
+    if (select_enabled_) {
+      auto is_selected_node = partial_match(selected_node_names_, node_name);
+      auto is_selected_topic = partial_match(selected_topic_names_, topic_name);
+
+      if (is_selected_node && selected_node_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+        return true;
+      }
+      if (is_selected_topic && selected_topic_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+        return true;
+
+      }
+      allowed_publishers_.insert(std::make_pair(publisher_handle, false));
+      return false;
+    } else if (ignore_enabled_) {
+      auto is_ignored_node = partial_match(ignored_node_names_, node_name);
+      auto is_ignored_topic = partial_match(ignored_topic_names_, topic_name);
+
+      if (is_ignored_node && ignored_node_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, false));
+        return false;
+      }
+      if (is_ignored_topic && ignored_topic_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, false));
+        return false;
+      }
+      allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+      return true;
+    }
+    allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+    return true;
+  }
+}
 
 std::string TracingController::to_node_name(const void * callback)
 {
@@ -321,4 +432,14 @@ void TracingController::add_timer_callback(
   std::lock_guard<std::shared_timed_mutex> lock(mutex_);
 
   callback_to_timer_handles_.insert(std::make_pair(callback, timer_handle));
+}
+
+void TracingController::add_publisher_handle(
+  const void * node_handle,
+  const void * publisher_handle,
+  std::string topic_name)
+{
+  std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+  publisher_handle_to_node_handles_.insert(std::make_pair(publisher_handle, node_handle));
+  publisher_handle_to_topic_names_.insert(std::make_pair(publisher_handle, topic_name));
 }

--- a/src/tracing_controller.cpp
+++ b/src/tracing_controller.cpp
@@ -38,6 +38,9 @@ bool partial_match(std::unordered_set<std::string> set, std::string target_name)
 {
   for (auto & condition : set) {
     try {
+      if (condition == "*") {
+        return true;
+      }
       std::regex re(condition.c_str());
       if (std::regex_search(target_name, re)) {
         return true;

--- a/src/tracing_controller.cpp
+++ b/src/tracing_controller.cpp
@@ -103,7 +103,7 @@ bool is_condition_valid(std::string condition)
 
 void check_condition_set(std::unordered_set<std::string> conditions)
 {
-  for (auto & condition: conditions) {
+  for (auto & condition : conditions) {
     if (!is_condition_valid(condition)) {
       std::string msg = "Failed to load regular expression \"" + condition + "\". Skip filtering.";
       RCLCPP_INFO(rclcpp::get_logger("caret"), msg.c_str());


### PR DESCRIPTION
特に`/clock`トピックの初期化トレースポイントが、Autowareを立ち上げた際に突発的に記録され、
その際にトレース結果のロストが発生していた。
CARETは初期化時に実行される関数からトピック名などとの紐付けに使うため、
初期化時のロストは測定を出来なくしてしまう。

元々/clockトピックのsubscription コールバックのstart/endといったランタイムのトレースポイントをフィルタリングするための機能であったが、
上記の問題が上がったため、初期化時のトレースポイントもフィルタリング対象に追加する。

ただし、初期化時のトレースポイントは関数の実行順序からノード名・トピック名と紐付けられない関数もある。
取り急ぎ、ノード名・トピック名と簡単に紐付けられる初期化関数のトレースフィルタリング適用をした。