### PR TITLE
 初期化時のトレースポイントにトレースフィルタリングの適用

### DIFF
--- a/include/caret_trace/tracing_controller.hpp
+++ b/include/caret_trace/tracing_controller.hpp
@@ -35,7 +35,7 @@ public:
     const void * subscription, const void * callback);
 
   void add_timer_handle(
-    const void * node_handle, const void * client_handle);
+    const void * node_handle, const void * timer_handle);
 
   void add_timer_callback(
     const void * timer_handle, const void * callback);

--- a/include/caret_trace/tracing_controller.hpp
+++ b/include/caret_trace/tracing_controller.hpp
@@ -37,10 +37,19 @@ public:
   void add_timer_handle(
     const void * node_handle, const void * timer_handle);
 
+  void add_publisher_handle(
+    const void * node_handle, const void * publisher_handle, std::string topic_name);
+
   void add_timer_callback(
     const void * timer_handle, const void * callback);
 
   bool is_allowed_callback(const void * callback);
+
+  bool is_allowed_node(const void * node_handle);
+
+  bool is_allowed_publisher_handle(const void * publisher_handle);
+
+  bool is_allowed_subscription_handle(const void * subscription_handle);
 
 private:
   std::shared_timed_mutex mutex_;
@@ -64,6 +73,10 @@ private:
   std::unordered_map<const void *, const void *> callback_to_timer_handles_;
   std::unordered_map<const void *, const void *> timer_handle_to_node_handles_;
   std::unordered_map<const void *, bool> allowed_callbacks_;
+
+  std::unordered_map<const void *, const void *> publisher_handle_to_node_handles_;
+  std::unordered_map<const void *, std::string> publisher_handle_to_topic_names_;
+  std::unordered_map<const void *, bool> allowed_publishers_;
 };
 
 #endif  // CARET_TRACE__TRACING_CONTROLLER_HPP_

--- a/src/hooked_trace_points.cpp
+++ b/src/hooked_trace_points.cpp
@@ -154,7 +154,7 @@ public:
   spin_once_impl(std::chrono::nanoseconds timeout) override;
 
 // private:
-  // RCLCPP_DISABLE_COPY(StaticSingleThreadedExecutor)
+// RCLCPP_DISABLE_COPY(StaticSingleThreadedExecutor)
 
   StaticExecutorEntitiesCollector::SharedPtr entities_collector_;
 };
@@ -596,11 +596,11 @@ void SYMBOL_CONCAT_3(
     const void *,
     bool);
   auto group_addr = static_cast<const void *>(group_ptr.get());
-  std::string  group_type_name = "unknown";
+  std::string group_type_name = "unknown";
   auto group_type = group_ptr->type();
-  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive){
+  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive) {
     group_type_name = "mutually_exclusive";
-  } else if (group_type == rclcpp::CallbackGroupType::Reentrant){
+  } else if (group_type == rclcpp::CallbackGroupType::Reentrant) {
     group_type_name = "reentrant";
   }
 
@@ -617,10 +617,10 @@ bool SYMBOL_CONCAT_3(
   _ZN6rclcpp9executors31StaticExecutorEntitiesCollector18add_callback_groupESt10shared_ptr,
   INS_13CallbackGroupEES2_INS_15node_interfaces17NodeBaseInterface,
   EERSt3mapISt8weak_ptrIS3_ES9_IS6_ESt10owner_lessISA_ESaISt4pairIKSA_SB_EEE) (
-    void * obj,
-    rclcpp::CallbackGroup::SharedPtr group_ptr,
-    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
-    rclcpp::memory_strategy::MemoryStrategy::WeakCallbackGroupsToNodesMap & weak_groups_to_nodes)
+  void * obj,
+  rclcpp::CallbackGroup::SharedPtr group_ptr,
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr,
+  rclcpp::memory_strategy::MemoryStrategy::WeakCallbackGroupsToNodesMap & weak_groups_to_nodes)
 {
   static void * orig_func = dlsym(RTLD_NEXT, __func__);
   using functionT = bool (*)(
@@ -630,17 +630,18 @@ bool SYMBOL_CONCAT_3(
     rclcpp::memory_strategy::MemoryStrategy::WeakCallbackGroupsToNodesMap &);
 
   auto group_addr = static_cast<const void *>(group_ptr.get());
-  std::string  group_type_name = "unknown";
+  std::string group_type_name = "unknown";
   auto group_type = group_ptr->type();
-  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive){
+  if (group_type == rclcpp::CallbackGroupType::MutuallyExclusive) {
     group_type_name = "mutually_exclusive";
-  } else if (group_type == rclcpp::CallbackGroupType::Reentrant){
+  } else if (group_type == rclcpp::CallbackGroupType::Reentrant) {
     group_type_name = "reentrant";
   }
 
   auto ret = ((functionT) orig_func)(obj, group_ptr, node_ptr, weak_groups_to_nodes);
 
-  tracepoint(TRACEPOINT_PROVIDER, add_callback_group_static_executor,
+  tracepoint(
+    TRACEPOINT_PROVIDER, add_callback_group_static_executor,
     obj, group_addr, group_type_name.c_str());
 #ifdef DEBUG_OUTPUT
   std::cerr << "add_callback_group_static_executor," << obj << "," << group_addr << "," <<

--- a/src/ros_trace_points.cpp
+++ b/src/ros_trace_points.cpp
@@ -128,7 +128,6 @@ void ros_trace_rclcpp_subscription_callback_added(
   }
 }
 
-#ifdef DEBUG_OUTPUT
 void ros_trace_rclcpp_timer_callback_added(const void * timer_handle, const void * callback)
 {
   static auto & controller = Singleton<TracingController>::get_instance();
@@ -139,12 +138,13 @@ void ros_trace_rclcpp_timer_callback_added(const void * timer_handle, const void
   using functionT = void (*)(const void *, const void *);
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(timer_handle, callback);
-  }
-  std::cerr << "rclcpp_timer_callback_added," <<
-    timer_handle << "," <<
-    callback << std::endl;
-}
+#ifdef DEBUG_OUTPUT
+    std::cerr << "rclcpp_timer_callback_added," <<
+      timer_handle << "," <<
+      callback << std::endl;
 #endif
+  }
+}
 
 void ros_trace_rclcpp_timer_link_node(const void * timer_handle, const void * node_handle)
 {
@@ -156,13 +156,12 @@ void ros_trace_rclcpp_timer_link_node(const void * timer_handle, const void * no
   using functionT = void (*)(const void *, const void *);
   if (controller.is_allowed_node(node_handle)) {
     ((functionT) orig_func)(timer_handle, node_handle);
-  }
-
 #ifdef DEBUG_OUTPUT
-  std::cerr << "rclcpp_timer_link_node," <<
-    timer_handle << "," <<
-    node_handle << std::endl;
+    std::cerr << "rclcpp_timer_link_node," <<
+      timer_handle << "," <<
+      node_handle << std::endl;
 #endif
+  }
 }
 
 void ros_trace_callback_start(const void * callback, bool is_intra_process)
@@ -174,13 +173,12 @@ void ros_trace_callback_start(const void * callback, bool is_intra_process)
 
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(callback, is_intra_process);
-  }
-
 #ifdef DEBUG_OUTPUT
-  std::cerr << "callback_start," <<
-    callback << "," <<
-    is_intra_process << std::endl;
+    std::cerr << "callback_start," <<
+      callback << "," <<
+      is_intra_process << std::endl;
 #endif
+  }
 }
 
 void ros_trace_callback_end(const void * callback)
@@ -191,12 +189,12 @@ void ros_trace_callback_end(const void * callback)
   using functionT = void (*)(const void *);
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(callback);
-  }
 
 #ifdef DEBUG_OUTPUT
-  std::cerr << "callback_end," <<
-    callback << std::endl;
+    std::cerr << "callback_end," <<
+      callback << std::endl;
 #endif
+  }
 }
 
 void ros_trace_dispatch_subscription_callback(
@@ -211,15 +209,15 @@ void ros_trace_dispatch_subscription_callback(
   using functionT = void (*)(const void *, const void *, const uint64_t, const uint64_t);
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(message, callback, source_timestamp, message_timestamp);
-  }
 
 #ifdef DEBUG_OUTPUT
-  std::cerr << "dispatch_subscription_callback," <<
-    message << "," <<
-    callback << "," <<
-    source_timestamp << "," <<
-    message_timestamp << std::endl;
+    std::cerr << "dispatch_subscription_callback," <<
+      message << "," <<
+      callback << "," <<
+      source_timestamp << "," <<
+      message_timestamp << std::endl;
 #endif
+  }
 }
 
 void ros_trace_dispatch_intra_process_subscription_callback(
@@ -233,14 +231,14 @@ void ros_trace_dispatch_intra_process_subscription_callback(
   using functionT = void (*)(const void *, const void *, const uint64_t);
   if (controller.is_allowed_callback(callback)) {
     ((functionT) orig_func)(message, callback, message_timestamp);
-  }
 
 #ifdef DEBUG_OUTPUT
-  std::cerr << "dispatch_intra_process_subscription_callback," <<
-    message << "," <<
-    callback << "," <<
-    message_timestamp << std::endl;
+    std::cerr << "dispatch_intra_process_subscription_callback," <<
+      message << "," <<
+      callback << "," <<
+      message_timestamp << std::endl;
 #endif
+  }
 }
 
 void ros_trace_rclcpp_publish(
@@ -284,6 +282,7 @@ void ros_trace_rclcpp_intra_publish(
   }
 }
 
+#ifdef DEBUG_OUTPUT
 void ros_trace_rcl_timer_init(
   const void * timer_handle,
   int64_t period)
@@ -293,12 +292,11 @@ void ros_trace_rcl_timer_init(
   using functionT = void (*)(const void *, int64_t);
   ((functionT) orig_func)(timer_handle, period);
 
-#ifdef DEBUG_OUTPUT
   std::cerr << "rcl_timer_init," <<
     timer_handle << "," <<
     period << std::endl;
-#endif
 }
+#endif
 
 #ifdef DEBUG_OUTPUT
 void ros_trace_rcl_init(
@@ -312,6 +310,8 @@ void ros_trace_rcl_init(
     context_handle << std::endl;
 }
 #endif
+
+#ifdef DEBUG_OUTPUT
 
 void ros_trace_rcl_publisher_init(
   const void * publisher_handle,
@@ -337,15 +337,14 @@ void ros_trace_rcl_publisher_init(
     rmw_publisher_handle,
     topic_name,
     queue_depth);
-#ifdef DEBUG_OUTPUT
   std::cerr << "rcl_publisher_init," <<
     publisher_handle << "," <<
     node_handle << "," <<
     rmw_publisher_handle << "," <<
     topic_name << "," <<
     queue_depth << std::endl;
-#endif
 }
+#endif
 
 void ros_trace_rcl_publish(
   const void * publisher_handle,

--- a/src/tracing_controller.cpp
+++ b/src/tracing_controller.cpp
@@ -177,31 +177,142 @@ bool TracingController::is_allowed_callback(const void * callback)
     auto topic_name = to_topic_name(callback);
 
     if (select_enabled_) {
-      auto is_selected_node = partial_match(selected_node_names_, node_name);
       auto is_selected_topic = partial_match(selected_topic_names_, topic_name);
-      if (is_selected_node || is_selected_topic) {
+      auto is_selected_node = partial_match(selected_node_names_, node_name);
+
+      if (selected_topic_names_.size() > 0 && is_selected_topic) {
         allowed_callbacks_.insert(std::make_pair(callback, true));
         return true;
-      } else {
-        allowed_callbacks_.insert(std::make_pair(callback, false));
-        return false;
       }
-    } else if (ignore_enabled_) {
+      if (selected_node_names_.size() > 0 && is_selected_node) {
+        allowed_callbacks_.insert(std::make_pair(callback, true));
+        return true;
+      }
+      if (selected_node_names_.size() == 0 && topic_name == "") { // allow timer callback
+        allowed_callbacks_.insert(std::make_pair(callback, true));
+        return true;
+      }
+
+      allowed_callbacks_.insert(std::make_pair(callback, false));
+      return false;
+    }
+    if (ignore_enabled_) {
       auto is_ignored_node = partial_match(ignored_node_names_, node_name);
       auto is_ignored_topic = partial_match(ignored_topic_names_, topic_name);
-      if (is_ignored_node || is_ignored_topic) {
+
+      if (ignored_node_names_.size() > 0 && is_ignored_node) {
         allowed_callbacks_.insert(std::make_pair(callback, false));
         return false;
-      } else {
-        allowed_callbacks_.insert(std::make_pair(callback, true));
-        return true;
       }
+      if (ignored_topic_names_.size() > 0 && is_ignored_topic) {
+        allowed_callbacks_.insert(std::make_pair(callback, false));
+        return false;
+      }
+      allowed_callbacks_.insert(std::make_pair(callback, true));
+      return true;
     }
     allowed_callbacks_.insert(std::make_pair(callback, true));
     return true;
   }
 }
 
+bool TracingController::is_allowed_node(const void * node_handle)
+{
+  std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+  auto node_name = node_handle_to_node_names_[node_handle];
+  if (select_enabled_ && selected_node_names_.size() > 0) {
+    auto is_selected_node = partial_match(selected_node_names_, node_name);
+    return is_selected_node;
+  } else if (ignore_enabled_ && ignored_node_names_.size() > 0) {
+    auto is_ignored_node = partial_match(ignored_node_names_, node_name);
+    return !is_ignored_node;
+  }
+  return true;
+}
+
+bool TracingController::is_allowed_subscription_handle(const void * subscription_handle)
+{
+  std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+  auto node_handle = subscription_handle_to_node_handles_[subscription_handle];
+  auto node_name = node_handle_to_node_names_[node_handle];
+  auto topic_name = subscription_handle_to_topic_names_[subscription_handle];
+
+  if (select_enabled_) {
+    auto is_selected_node = partial_match(selected_node_names_, node_name);
+    auto is_selected_topic = partial_match(selected_topic_names_, topic_name);
+
+    if (is_selected_node && selected_node_names_.size() > 0) {
+      return true;
+    }
+    if (is_selected_topic && selected_topic_names_.size() > 0) {
+      return true;
+    }
+    return false;
+  } else if (ignore_enabled_) {
+    auto is_ignored_node = partial_match(ignored_node_names_, node_name);
+    auto is_ignored_topic = partial_match(ignored_topic_names_, topic_name);
+
+    if (is_ignored_node && ignored_node_names_.size() > 0) {
+      return false;
+    }
+    if (is_ignored_topic && ignored_topic_names_.size() > 0) {
+      return false;
+    }
+    return true;
+  }
+  return true;
+}
+
+bool TracingController::is_allowed_publisher_handle(const void * publisher_handle)
+{
+  std::unordered_map<const void *, bool>::iterator is_allowed_it;
+  {
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+    is_allowed_it = allowed_publishers_.find(publisher_handle);
+    if (is_allowed_it != allowed_publishers_.end() ) {
+      return is_allowed_it->second;
+    }
+  }
+  {
+    std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+    auto node_handle = publisher_handle_to_node_handles_[publisher_handle];
+    auto node_name = node_handle_to_node_names_[node_handle];
+    auto topic_name = publisher_handle_to_topic_names_[publisher_handle];
+
+    if (select_enabled_) {
+      auto is_selected_node = partial_match(selected_node_names_, node_name);
+      auto is_selected_topic = partial_match(selected_topic_names_, topic_name);
+
+      if (is_selected_node && selected_node_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+        return true;
+      }
+      if (is_selected_topic && selected_topic_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+        return true;
+
+      }
+      allowed_publishers_.insert(std::make_pair(publisher_handle, false));
+      return false;
+    } else if (ignore_enabled_) {
+      auto is_ignored_node = partial_match(ignored_node_names_, node_name);
+      auto is_ignored_topic = partial_match(ignored_topic_names_, topic_name);
+
+      if (is_ignored_node && ignored_node_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, false));
+        return false;
+      }
+      if (is_ignored_topic && ignored_topic_names_.size() > 0) {
+        allowed_publishers_.insert(std::make_pair(publisher_handle, false));
+        return false;
+      }
+      allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+      return true;
+    }
+    allowed_publishers_.insert(std::make_pair(publisher_handle, true));
+    return true;
+  }
+}
 
 std::string TracingController::to_node_name(const void * callback)
 {
@@ -321,4 +432,14 @@ void TracingController::add_timer_callback(
   std::lock_guard<std::shared_timed_mutex> lock(mutex_);
 
   callback_to_timer_handles_.insert(std::make_pair(callback, timer_handle));
+}
+
+void TracingController::add_publisher_handle(
+  const void * node_handle,
+  const void * publisher_handle,
+  std::string topic_name)
+{
+  std::lock_guard<std::shared_timed_mutex> lock(mutex_);
+  publisher_handle_to_node_handles_.insert(std::make_pair(publisher_handle, node_handle));
+  publisher_handle_to_topic_names_.insert(std::make_pair(publisher_handle, topic_name));
 }

--- a/src/tracing_controller.cpp
+++ b/src/tracing_controller.cpp
@@ -38,6 +38,9 @@ bool partial_match(std::unordered_set<std::string> set, std::string target_name)
 {
   for (auto & condition : set) {
     try {
+      if (condition == "*") {
+        return true;
+      }
       std::regex re(condition.c_str());
       if (std::regex_search(target_name, re)) {
         return true;


### PR DESCRIPTION
特に/clockトピックの初期化トレースポイントが、Autowareを立ち上げた際に突発的に記録され、
その際にトレース結果のロストが発生していた。
CARETは初期化時に実行される関数からトピック名などとの紐付けに使うため、
初期化時のロストは測定を出来なくしてしまう。

元々/clockトピックのsubscription コールバックのstart/endといったランタイムのトレースポイントをフィルタリングするための機能であったが、
上記の問題が上がったため、初期化時のトレースポイントもフィルタリング対象に追加する。

ただし、初期化時のトレースポイントは関数の実行順序からノード名・トピック名と紐付けられない関数もある。
取り急ぎ、ノード名・トピック名と簡単に紐付けられる初期化関数のトレースフィルタリング適用をした。