### PR TITLE
chore(sync-files): modify sync origin to caret_common

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -8,8 +8,6 @@
     - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
-    - source: .pre-commit-config.yaml
-    - source: .pre-commit-config-optional.yaml
     - source: .prettierignore
     - source: .prettierrc.yaml
     - source: .yamllint.yaml
@@ -26,3 +24,5 @@
 - repository: tier4/caret_common
   files:
     - source: .cspell.json
+    - source: .pre-commit-config.yaml
+    - source: .pre-commit-config-optional.yaml


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR modify sync origin to caret_common.

This PR is needed to merge https://github.com/tier4/CARET_trace/pull/45.
Note that cpplint and clang-format are to be removed!

Changes: (differences between [current .pre-commit-config.yaml](https://github.com/tier4/CARET_trace/blob/main/.pre-commit-config.yaml) and [caret_common's pre-commit-config.yaml](https://github.com/tier4/caret_common/blob/main/.pre-commit-config.yaml))

- hadolint-py is removed (not related for this repo because hadolint-py is tool for dockerfile)
- isort is added (not related for this repo because isort is tool for python)
- black is added (not related for this repo because black is tool for python)

Major changes are not related for this repo, but sync-files can be applied.