### PR TITLE
chore(github action): ignore version for tj-actions/changed-files in sync files

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -19,6 +19,9 @@
   files:
     - source: .github/workflows/build-and-test.yaml
     - source: .github/workflows/build-and-test-differential.yaml
+      pre-commands: |
+        VERSION=$(grep -P -o "(?<=tj\-actions/changed\-files@).+" {dest})
+        sd "tj-actions/changed-files@(.+)" "tj-actions/changed-files@"$VERSION {source}
     - source: .github/workflows/build-and-test-differential-self-hosted.yaml
     - source: .github/workflows/build-and-test-self-hosted.yaml
     - source: .github/workflows/check-build-depends.yaml


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR fixes conflicts between sync-files and dependabot

- https://github.com/tier4/CARET_trace/pull/71
- https://github.com/tier4/CARET_trace/pull/67