### PR TITLE
chore(github action): disable galactic tests

### DIFF
--- a/.github/workflows/build-and-test-differential-self-hosted.yaml
+++ b/.github/workflows/build-and-test-differential-self-hosted.yaml
@@ -23,12 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro:
-          - galactic
           - humble
         include:
-          - rosdistro: galactic
-            container: ros:galactic
-            build-depends-repos: build_depends.repos
           - rosdistro: humble
             container: ros:humble
             build-depends-repos: build_depends.repos

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -11,12 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro:
-          - galactic
           - humble
         include:
-          - rosdistro: galactic
-            container: ros:galactic
-            build-depends-repos: build_depends.repos
           - rosdistro: humble
             container: ros:humble
             build-depends-repos: build_depends.repos

--- a/.github/workflows/build-and-test-self-hosted.yaml
+++ b/.github/workflows/build-and-test-self-hosted.yaml
@@ -13,12 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro:
-          - galactic
           - humble
         include:
-          - rosdistro: galactic
-            container: ros:galactic
-            build-depends-repos: build_depends.repos
           - rosdistro: humble
             container: ros:humble
             build-depends-repos: build_depends.repos

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,12 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro:
-          - galactic
           - humble
         include:
-          - rosdistro: galactic
-            container: ros:galactic
-            build-depends-repos: build_depends.repos
           - rosdistro: humble
             container: ros:humble
             build-depends-repos: build_depends.repos

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -13,12 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro:
-          - galactic
           - humble
         include:
-          - rosdistro: galactic
-            container: ros:galactic
-            build-depends-repos: build_depends.repos
           - rosdistro: humble
             container: ros:humble
             build-depends-repos: build_depends.repos


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR disalbes test related to galactic.
galactic tests are not necessory because [caret.repos](https://github.com/tier4/caret/blob/galactic/caret.repos) doesn't use main branch for galactic version.

#68 tests fail in  `build-and-test-differential (galactic)` because it uses lttng2.13 features.