### PR TITLE
feat: add warning when /clock is not published

### DIFF
--- a/CARET_trace/src/clock_recorder.cpp
+++ b/CARET_trace/src/clock_recorder.cpp
@@ -37,14 +37,21 @@ public:
       // std::cout << static_cast<int>(now.seconds()) << std::endl;
       // The /clock topic will not be recorded while it is not published.
       if (now.nanoseconds() == 0) {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *timer_steady_, 3000,  // per 3 second.
+          "Failed to get simtime correctly. /clock topic may not have been published.");
         return;
       }
       RCLCPP_DEBUG(get_logger(), "sim_time recorded: %ld.", now.nanoseconds());
       tracepoint(TRACEPOINT_PROVIDER, sim_time, now.nanoseconds());
     };
     timer_ = create_wall_timer(1s, timer_callback);
+    timer_steady_ = std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME);
   }
+
+private:
   rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Clock::SharedPtr timer_steady_;
 };
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR adds warning log in clock_recorder node when /clock is not published.

To reproduce:

```
mkdir -p ~/ros2_ws_test/src
cd ~/ros2_ws_test/src

git clone https://github.com/hsgwa/CARET_trace.git feat_add_warn_if_simtime_is_unable
git clone https://github.com/hsgwa/clock_publisher.git
cd ~/ros2_ws_test
. /opt/ros/humble/setup.bash
colcon build


. ./install/setup.bash
ros2 run caret_trace clock_recorder
> clock_recorder started to record sim time.
> Failed to get simtime correctly. /clock topic may  note have been published.


. ./install/setup.bash
ros2 run clock_publisher publisher
```