### PR TITLE
fix: revert "ci: stop sync until autoware_common stops Galactic support."

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -15,15 +15,14 @@
 
 - repository: autowarefoundation/autoware_common
   files:
-    # stop sync until autoware_common stops Galactic support.
-    # - source: .github/workflows/build-and-test.yaml
-    # - source: .github/workflows/build-and-test-differential.yaml
-    #   pre-commands: |
-    #     VERSION=$(grep -P -o "(?<=tj\-actions/changed\-files@).+" {dest})
-    #     sd "tj-actions/changed-files@(.+)" "tj-actions/changed-files@"$VERSION {source}
-    # - source: .github/workflows/build-and-test-differential-self-hosted.yaml
-    # - source: .github/workflows/build-and-test-self-hosted.yaml
-    # - source: .github/workflows/check-build-depends.yaml
+    - source: .github/workflows/build-and-test.yaml
+    - source: .github/workflows/build-and-test-differential.yaml
+      pre-commands: |
+        VERSION=$(grep -P -o "(?<=tj\-actions/changed\-files@).+" {dest})
+        sd "tj-actions/changed-files@(.+)" "tj-actions/changed-files@"$VERSION {source}
+    - source: .github/workflows/build-and-test-differential-self-hosted.yaml
+    - source: .github/workflows/build-and-test-self-hosted.yaml
+    - source: .github/workflows/check-build-depends.yaml
 
 - repository: tier4/caret_common
   files:


### PR DESCRIPTION
Reverts tier4/CARET_trace#78

sync_file fails.

https://github.com/tier4/CARET_trace/actions/runs/3512256621/jobs/5883782026#step:12:282