### PR TITLE
feat: ignore rcl_timer_init() from ros2 launch command

### DIFF
--- a/CARET_trace/src/ros_trace_points.cpp
+++ b/CARET_trace/src/ros_trace_points.cpp
@@ -52,23 +52,29 @@
 std::unique_ptr<std::thread> trace_node_thread;
 thread_local bool trace_filter_is_rcl_publish_recorded;
 
-using namespace std;
+using std::string;
+using std::vector;
 bool ignore_rcl_timer_init = false;
 
 vector<string> string_split(string &str, char delim) {
-    vector<string> elems;
-    stringstream ss(str);
-    string item;
-    while (getline(ss, item, delim)) {
+  using std::stringstream;
+  vector<string> elems;
+  stringstream ss(str);
+  string item;
+  while (getline(ss, item, delim)) {
     if (!item.empty()) {
-            elems.push_back(item);
-        }
+      elems.push_back(item);
     }
-    return elems;
+  }
+  return elems;
 }
 
 bool is_ros2_launch_command()
 {
+  using std::ios;
+  using std::ifstream;
+  using std::istreambuf_iterator;
+  using std::to_string;
   pid_t pid = getpid();
   string fileName = "/proc/" + to_string(pid) + "/cmdline";
 

--- a/CARET_trace/src/ros_trace_points.cpp
+++ b/CARET_trace/src/ros_trace_points.cpp
@@ -70,14 +70,8 @@ static vector<string> string_split(string & str, char delim)
   return elems;
 }
 
-static bool is_ros2_launch_command()
+static bool is_python3_command()
 {
-  // Caret_trace's <TraceNode> should not record rcl_timer_init() for command line
-  // "python3" launch.
-  // This is because there are multiple processes that repeat spin_once() in a short time
-  // in the process started by "python3".
-  // If this is not excluded, the end time will increase as time passes
-  // after Caret_trace starts.
   using std::ifstream;
   using std::ios;
   using std::istreambuf_iterator;
@@ -112,7 +106,7 @@ static bool is_ros2_launch_command()
   }
 
   // Check if the right side of the last '/' in cmdline[0] matches 'python3'.
-  if (cmd_line.size() < 2) {
+  if (cmd_line.size() < 1) {
     return false;
   }
   // case 1 : /usr/bin/python3 /opt/ros/humble/bin/ros2 launch ...
@@ -161,7 +155,7 @@ void run_caret_trace_node()
   auto trace_node = std::make_shared<TraceNode>(node_name_base, option, lttng, data_container);
   RCLCPP_INFO(trace_node->get_logger(), "%s started", trace_node->get_fully_qualified_name());
 
-  ignore_rcl_timer_init = is_ros2_launch_command();
+  ignore_rcl_timer_init = is_python3_command();
 
   context.assign_node(trace_node);
   auto exec = rclcpp::executors::SingleThreadedExecutor();

--- a/CARET_trace/src/ros_trace_points.cpp
+++ b/CARET_trace/src/ros_trace_points.cpp
@@ -59,7 +59,7 @@ bool filter_launch_node() {
   char cmd_str[1024];
   char result_str[1024];
 
-  sprintf( cmd_str, "ps -ax |grep \"ros2 launch\" | grep %d", pid);
+  snprintf( cmd_str, sizeof(cmd_str), "ps -ax |grep \"ros2 launch\" | grep %d", pid);
   fp = popen( cmd_str, "r" );
   if ( fgets( result_str, sizeof(result_str), fp ) == NULL ) {
     pclose(fp);

--- a/CARET_trace/src/ros_trace_points.cpp
+++ b/CARET_trace/src/ros_trace_points.cpp
@@ -106,11 +106,11 @@ static bool is_python3_command()
   }
 
   // Check if the right side of the last '/' in cmdline[0] matches 'python3'.
+  //   pattern 1: /usr/bin/python3 /opt/ros/humble/bin/ros2 launch ...
+  //   pattern 2: python3 /opt/ros/humble/lib/rosbridge_server/rosbridge_websocket ...
   if (cmd_line.size() < 1) {
     return false;
   }
-  // case 1 : /usr/bin/python3 /opt/ros/humble/bin/ros2 launch ...
-  // case 2 :  python3 /opt/ros/humble/lib/rosbridge_server/rosbridge_websocket ...
   if (cmd_line[0].find("python3") == string::npos) {
     return false;
   }

--- a/CARET_trace/src/ros_trace_points.cpp
+++ b/CARET_trace/src/ros_trace_points.cpp
@@ -54,9 +54,9 @@ thread_local bool trace_filter_is_rcl_publish_recorded;
 
 using std::string;
 using std::vector;
-bool ignore_rcl_timer_init = false;
+static bool ignore_rcl_timer_init = false;
 
-vector<string> string_split(string &str, char delim) {
+static vector<string> string_split(string &str, char delim) {
   using std::stringstream;
   vector<string> elems;
   stringstream ss(str);
@@ -69,7 +69,7 @@ vector<string> string_split(string &str, char delim) {
   return elems;
 }
 
-bool is_ros2_launch_command()
+static bool is_ros2_launch_command()
 {
   using std::ios;
   using std::ifstream;
@@ -85,7 +85,7 @@ bool is_ros2_launch_command()
   istreambuf_iterator<char> it_ifs_begin(ifs);
   istreambuf_iterator<char> it_ifs_end{};
   vector<char> input_data(it_ifs_begin, it_ifs_end);
-  if (ifs.fail()) {
+  if (!ifs) {
     ifs.close();
     return false;
   }
@@ -105,6 +105,9 @@ bool is_ros2_launch_command()
   }
 
   // Checkpoint 1 : cmdline[0] contains "python"
+  if (cmd_line.size() <= 2) {
+    return false;
+  }
   if (cmd_line[0].find("python") == string::npos) {
     return false;
   }
@@ -638,7 +641,7 @@ void ros_trace_rcl_timer_init(
   static auto & data_container = context.get_data_container();
   // TODO(hsgwa): Add filtering of timer initialization using node_handle
 
-  if ( ignore_rcl_timer_init == true) {
+  if (ignore_rcl_timer_init == true) {
     return;
   }
 


### PR DESCRIPTION
## Description

Some of the processes started with python3 had a process that issued rcl_timer_init() not associated with a node in a short cycle.
As a result, the information acquired by CARET_trace increases with the passage of time, and a phenomenon occurs in which it takes time to complete measurement.
For this reason, restrict rcl_timer_init() to be excluded when invoked by the python3 command.
(memo)Currently, measurement via python3 (rclpy) is not supported.

## Related links

https://tier4.atlassian.net/browse/RT2-591

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
