### PR TITLE
fix: controlling the dds_bind_addr_to_stamp output of generic_publish()

### DIFF
--- a/CARET_trace/src/hooked_trace_points.cpp
+++ b/CARET_trace/src/hooked_trace_points.cpp
@@ -68,6 +68,15 @@ namespace FASTDDS
 static void * SET_FRAGMENTS;
 }
 
+bool is_jazzy_or_later()
+{
+  const char * ros_distro = std::getenv("ROS_DISTRO");
+  if (ros_distro[0] >= "jazzy"[0]) {
+    return true;
+  }
+  return false;
+}
+
 namespace rclcpp
 {
 namespace executors
@@ -262,7 +271,8 @@ int dds_writecdr_impl(void * wr, void * xp, struct ddsi_serdata * dinp, bool flu
     return dds_return;
   }
 
-  if (context.is_recording_allowed() && trace_filter_is_rcl_publish_recorded) {
+  bool filter = is_jazzy_or_later()? trace_filter_is_rcl_publish_recorded: true;
+  if (context.is_recording_allowed() && filter) {
     tracepoint(
       TRACEPOINT_PROVIDER, dds_bind_addr_to_stamp, serialized_message_addr, dinp->timestamp.v);
 #ifdef DEBUG_OUTPUT

--- a/CARET_trace/src/hooked_trace_points.cpp
+++ b/CARET_trace/src/hooked_trace_points.cpp
@@ -271,7 +271,7 @@ int dds_writecdr_impl(void * wr, void * xp, struct ddsi_serdata * dinp, bool flu
     return dds_return;
   }
 
-  bool filter = is_jazzy_or_later()? trace_filter_is_rcl_publish_recorded: true;
+  bool filter = is_jazzy_or_later() ? trace_filter_is_rcl_publish_recorded : true;
   if (context.is_recording_allowed() && filter) {
     tracepoint(
       TRACEPOINT_PROVIDER, dds_bind_addr_to_stamp, serialized_message_addr, dinp->timestamp.v);


### PR DESCRIPTION
The dds_bind_addr_to_stamp output of **generic_publish()** is controlled as follows.
- Before jazzy: Always output.
- After jazzy: Those associated with rcl_publish are subject to the filter.

## Related links

[https://tier4.atlassian.net/browse/RT2-1640](url)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
