### PR TITLE
fix: uninitialized variables

### DIFF
--- a/CARET_trace/src/ros_trace_points.cpp
+++ b/CARET_trace/src/ros_trace_points.cpp
@@ -93,7 +93,7 @@ static bool is_python3_command()
   }
   ifs.close();
 
-  vector<string> cmd_line;
+  vector<string> cmd_line = {};
   auto itr_begin = input_data.begin();
   auto itr_find = input_data.begin();
   for (;;) {

--- a/CARET_trace/src/ros_trace_points.cpp
+++ b/CARET_trace/src/ros_trace_points.cpp
@@ -93,7 +93,7 @@ static bool is_python3_command()
   }
   ifs.close();
 
-  vector<string> cmd_line = {};
+  vector<string> cmd_line;
   auto itr_begin = input_data.begin();
   auto itr_find = input_data.begin();
   for (;;) {

--- a/CARET_trace/src/tracing_controller.cpp
+++ b/CARET_trace/src/tracing_controller.cpp
@@ -57,7 +57,7 @@ std::unordered_set<std::string> split(std::string str, char del)
 {
   std::unordered_set<std::string> result;
   std::string::size_type first = 0;
-  std::string::size_type last;
+  std::string::size_type last = 0;
 
   while (first < str.size()) {
     last = str.find_first_of(del, first);


### PR DESCRIPTION
## Description

Of the clang-tidy pointers, the following items should be checked
* misc-unused-parameters
* cppcoreguidelines-init-variables (uninitialised variables)
* cppcoreguidelines-pro-type-member-init (uninitialised member variables)
* cppcoreguidelines-narrowing-conversions (precision loss)
Code checks extracted two cases of code to be corrected in relation to cppcoreguidelines-init-variables.

## Related links

[https://tier4.atlassian.net/browse/RT2-738](https://tier4.atlassian.net/browse/RT2-738)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
