### PR TITLE
fix: remove pull-request trriger in cppcheck-all-files

### DIFF
--- a/.github/workflows/cppcheck-all-files.yaml
+++ b/.github/workflows/cppcheck-all-files.yaml
@@ -1,7 +1,6 @@
 name: cppcheck-all-files
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Remove the pull-request trriger in cppcheck-all-files.

## Related links

[https://tier4.atlassian.net/browse/RT2-1667](https://tier4.atlassian.net/browse/RT2-1667)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
