### PR TITLE
chore: add warning indicating sim_time reversal detection

### DIFF
--- a/CARET_trace/src/clock_recorder.cpp
+++ b/CARET_trace/src/clock_recorder.cpp
@@ -23,6 +23,7 @@
 
 using namespace std::literals::chrono_literals;
 
+// cspell:ignore rostime
 /// @brief Node class to record rostime.
 /// @details Subscribe to /clock topic and record simtime every second.
 class ClockRecorder : public rclcpp::Node

--- a/CARET_trace/src/clock_recorder.cpp
+++ b/CARET_trace/src/clock_recorder.cpp
@@ -28,7 +28,7 @@ using namespace std::literals::chrono_literals;
 class ClockRecorder : public rclcpp::Node
 {
 public:
-  ClockRecorder() : Node("clock_recorder")
+  ClockRecorder() : Node("clock_recorder"), previous_now_(0), inflection_(0)
   {
     auto use_sim_time = rclcpp::Parameter("use_sim_time", true);
     set_parameter(use_sim_time);
@@ -44,6 +44,13 @@ public:
           "Failed to get simtime correctly. /clock topic may not have been published.");
         return;
       }
+      inflection_++;
+      if (previous_now_.nanoseconds() != 0) {
+        if (now.nanoseconds() < previous_now_.nanoseconds()) {
+            RCLCPP_WARN(get_logger(), "### sim_time decreased: %ld -> %ld at [%d]", previous_now_.nanoseconds(), now.nanoseconds(), inflection_);
+        }
+      }
+      previous_now_ = now;
       RCLCPP_DEBUG(get_logger(), "sim_time recorded: %ld.", now.nanoseconds());
       tracepoint(TRACEPOINT_PROVIDER, sim_time, now.nanoseconds());
     };
@@ -54,6 +61,8 @@ public:
 private:
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Clock::SharedPtr timer_steady_;
+  rclcpp::Time previous_now_;
+  int inflection_;
 };
 
 int main(int argc, char ** argv)

--- a/CARET_trace/src/clock_recorder.cpp
+++ b/CARET_trace/src/clock_recorder.cpp
@@ -47,7 +47,9 @@ public:
       inflection_++;
       if (previous_now_.nanoseconds() != 0) {
         if (now.nanoseconds() < previous_now_.nanoseconds()) {
-            RCLCPP_WARN(get_logger(), "Detect sim_time decreased: %ld -> %ld at [%d]", previous_now_.nanoseconds(), now.nanoseconds(), inflection_);
+          RCLCPP_WARN(
+            get_logger(), "Detect sim_time decreased: %ld -> %ld at [%d]",
+            previous_now_.nanoseconds(), now.nanoseconds(), inflection_);
         }
       }
       previous_now_ = now;

--- a/CARET_trace/src/clock_recorder.cpp
+++ b/CARET_trace/src/clock_recorder.cpp
@@ -47,7 +47,7 @@ public:
       inflection_++;
       if (previous_now_.nanoseconds() != 0) {
         if (now.nanoseconds() < previous_now_.nanoseconds()) {
-            RCLCPP_WARN(get_logger(), "### sim_time decreased: %ld -> %ld at [%d]", previous_now_.nanoseconds(), now.nanoseconds(), inflection_);
+            RCLCPP_WARN(get_logger(), "Detect sim_time decreased: %ld -> %ld at [%d]", previous_now_.nanoseconds(), now.nanoseconds(), inflection_);
         }
       }
       previous_now_ = now;


### PR DESCRIPTION
## Description

Add a warning indicating sim_time reversal detection.
MSG: Detect sim_time decreased: <previous time> -> <current time> at [<count of wall timer timeout>]

## Related links

[https://tier4.atlassian.net/browse/RT2-2003](https://tier4.atlassian.net/browse/RT2-2003)

## Notes for reviewers

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
