### PR TITLE
refactor: remove CycloneDDS source bundling by leveraging public APIs

### DIFF
--- a/CARET_trace/src/hooked_trace_points.cpp
+++ b/CARET_trace/src/hooked_trace_points.cpp
@@ -56,7 +56,7 @@ extern thread_local bool trace_filter_is_rcl_publish_recorded;
 // Declare a prototype in order to use the functions implemented in cyclonedds.
 rmw_ret_t rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid);
 
-// cspell: ignore WRITECDR
+// cspell: ignore WRITECDR ddsi serdata ERKNS IKSA
 namespace CYCLONEDDS
 {
 // humble : dds_write, dds_writecdr

--- a/CARET_trace/src/hooked_trace_points.cpp
+++ b/CARET_trace/src/hooked_trace_points.cpp
@@ -59,11 +59,12 @@ rmw_ret_t rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t
 // cspell: ignore WRITECDR
 namespace CYCLONEDDS
 {
-  // humble : dds_write, dds_writecdr
+  // humble : dds_write, dds_writecdr and dds_time
   // jazzy : dds_write, dds_write_ts
   void * DDS_WRITE;
   void * DDS_WRITE_TS;
   void * DDS_WRITECDR;
+  void * DDS_TIME;
 }  // namespace CYCLONEDDS
 
 // For FastDDS
@@ -241,12 +242,8 @@ void update_dds_function_addr()
   } else if (env_var == "rmw_cyclonedds_cpp") {
     CYCLONEDDS::DDS_WRITE = lib->get_symbol("dds_write");
     CYCLONEDDS::DDS_WRITE_TS = lib->get_symbol("dds_write_ts");
-
-    if (!is_jazzy_or_later()) {
-      CYCLONEDDS::DDS_WRITECDR = lib->get_symbol("dds_writecdr");
-    } else {
-      CYCLONEDDS::DDS_WRITECDR = nullptr;
-    }
+    CYCLONEDDS::DDS_WRITECDR = lib->get_symbol("dds_writecdr");
+    CYCLONEDDS::DDS_TIME = lib->get_symbol("dds_time");
   }
 }
 
@@ -259,6 +256,7 @@ int dds_write(void * wr, void * data)  // NOLINT
   static auto & context = Singleton<Context>::get_instance();
   static auto & clock = context.get_clock();
   using functionT = int (*)(void *, void *, int64_t);  // NOLINT
+  using function_orig_T = int (*)(void *, void *);  // NOLINT
 
   if (CYCLONEDDS::DDS_WRITE_TS == nullptr) {
     update_dds_function_addr();
@@ -270,6 +268,8 @@ int dds_write(void * wr, void * data)  // NOLINT
   int dds_return = 0;
   if (CYCLONEDDS::DDS_WRITE_TS != nullptr) {
     dds_return = ((functionT)CYCLONEDDS::DDS_WRITE_TS)(wr, data, tstamp);
+  } else if (CYCLONEDDS::DDS_WRITE != nullptr) {
+    dds_return = ((function_orig_T)CYCLONEDDS::DDS_WRITE)(wr, data);
   }
 
   if (context.is_recording_allowed() && trace_filter_is_rcl_publish_recorded) {
@@ -309,6 +309,26 @@ int dds_write_ts(void * wr, void * data, int64_t tstamp)  // NOLINT
   return dds_return;
 }
 
+// for cyclonedds: dds_writecdr
+static thread_local bool in_dds_writecdr_context = false;
+static thread_local int64_t forced_dds_timestamp = 0;
+
+int64_t dds_time(void) // NOLINT
+{
+  static auto & context = Singleton<Context>::get_instance();
+  using functionT = int64_t (*)(void); // NOLINT
+
+  if (CYCLONEDDS::DDS_TIME == nullptr) {
+    update_dds_function_addr();
+  }
+
+  if (in_dds_writecdr_context) {
+    return forced_dds_timestamp;
+  }
+
+  return ((functionT)CYCLONEDDS::DDS_TIME)();
+}
+
 // for cyclonedds: humble / iron
 int dds_writecdr(void * writer, struct ddsi_serdata * serdata) // NOLINT
 {
@@ -319,7 +339,6 @@ int dds_writecdr(void * writer, struct ddsi_serdata * serdata) // NOLINT
     update_dds_function_addr();
   }
 
-  // except jazzy
   if (CYCLONEDDS::DDS_WRITECDR == nullptr || !context.get_controller().is_allowed_process()) {
     if (CYCLONEDDS::DDS_WRITECDR != nullptr) {
       return ((functionT)CYCLONEDDS::DDS_WRITECDR)(writer, serdata);
@@ -327,7 +346,9 @@ int dds_writecdr(void * writer, struct ddsi_serdata * serdata) // NOLINT
     return 0;
   }
 
+  in_dds_writecdr_context = true;
   int dds_return = ((functionT)CYCLONEDDS::DDS_WRITECDR)(writer, serdata);
+  in_dds_writecdr_context = false;
 
   bool filter = is_jazzy_or_later() ? trace_filter_is_rcl_publish_recorded : true;
   if (context.is_recording_allowed() && filter) {

--- a/CARET_trace/src/hooked_trace_points.cpp
+++ b/CARET_trace/src/hooked_trace_points.cpp
@@ -59,12 +59,11 @@ rmw_ret_t rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t
 // cspell: ignore WRITECDR
 namespace CYCLONEDDS
 {
-  // humble : dds_write, dds_writecdr and dds_time
+  // humble : dds_write, dds_writecdr
   // jazzy : dds_write, dds_write_ts
   void * DDS_WRITE;
   void * DDS_WRITE_TS;
   void * DDS_WRITECDR;
-  void * DDS_TIME;
 }  // namespace CYCLONEDDS
 
 // For FastDDS
@@ -243,7 +242,6 @@ void update_dds_function_addr()
     CYCLONEDDS::DDS_WRITE = lib->get_symbol("dds_write");
     CYCLONEDDS::DDS_WRITE_TS = lib->get_symbol("dds_write_ts");
     CYCLONEDDS::DDS_WRITECDR = lib->get_symbol("dds_writecdr");
-    CYCLONEDDS::DDS_TIME = lib->get_symbol("dds_time");
   }
 }
 
@@ -262,7 +260,7 @@ int dds_write(void * wr, void * data)  // NOLINT
     update_dds_function_addr();
   }
 
-  int64_t tstamp = clock.now();
+  int64_t tstamp = dds_time();
 
   // Call dds_write_ts instead of dds_write to get the timestamp for recording.
   int dds_return = 0;
@@ -272,7 +270,8 @@ int dds_write(void * wr, void * data)  // NOLINT
     dds_return = ((function_orig_T)CYCLONEDDS::DDS_WRITE)(wr, data);
   }
 
-  if (context.is_recording_allowed() && trace_filter_is_rcl_publish_recorded) {
+  bool filter = is_jazzy_or_later() ? trace_filter_is_rcl_publish_recorded : true;
+  if (context.is_recording_allowed() && filter) {
     tracepoint(TRACEPOINT_PROVIDER, dds_bind_addr_to_stamp, data, tstamp);
 #ifdef DEBUG_OUTPUT
     std::cerr << "dds_bind_addr_to_stamp," << data << "," << tstamp << std::endl;
@@ -281,6 +280,7 @@ int dds_write(void * wr, void * data)  // NOLINT
   return dds_return;
 }
 
+// for cyclonedds: jazzy and rolling
 int dds_write_ts(void * wr, void * data, int64_t tstamp)  // NOLINT
 {
   static auto & context = Singleton<Context>::get_instance();
@@ -290,7 +290,6 @@ int dds_write_ts(void * wr, void * data, int64_t tstamp)  // NOLINT
     update_dds_function_addr();
   }
   
-  // use rmw timestamp
   int dds_return = 0;
   if (CYCLONEDDS::DDS_WRITE_TS != nullptr) {
     dds_return = ((functionT)CYCLONEDDS::DDS_WRITE_TS)(wr, data, tstamp);
@@ -307,26 +306,6 @@ int dds_write_ts(void * wr, void * data, int64_t tstamp)  // NOLINT
 #endif
   }
   return dds_return;
-}
-
-// for cyclonedds: dds_writecdr
-static thread_local bool in_dds_writecdr_context = false;
-static thread_local int64_t forced_dds_timestamp = 0;
-
-int64_t dds_time(void) // NOLINT
-{
-  static auto & context = Singleton<Context>::get_instance();
-  using functionT = int64_t (*)(void); // NOLINT
-
-  if (CYCLONEDDS::DDS_TIME == nullptr) {
-    update_dds_function_addr();
-  }
-
-  if (in_dds_writecdr_context) {
-    return forced_dds_timestamp;
-  }
-
-  return ((functionT)CYCLONEDDS::DDS_TIME)();
 }
 
 // for cyclonedds: humble / iron
@@ -346,9 +325,7 @@ int dds_writecdr(void * writer, struct ddsi_serdata * serdata) // NOLINT
     return 0;
   }
 
-  in_dds_writecdr_context = true;
   int dds_return = ((functionT)CYCLONEDDS::DDS_WRITECDR)(writer, serdata);
-  in_dds_writecdr_context = false;
 
   bool filter = is_jazzy_or_later() ? trace_filter_is_rcl_publish_recorded : true;
   if (context.is_recording_allowed() && filter) {

--- a/CARET_trace/src/hooked_trace_points.cpp
+++ b/CARET_trace/src/hooked_trace_points.cpp
@@ -59,11 +59,11 @@ rmw_ret_t rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t
 // cspell: ignore WRITECDR
 namespace CYCLONEDDS
 {
-  // humble : dds_write, dds_writecdr
-  // jazzy : dds_write, dds_write_ts
-  void * DDS_WRITE;
-  void * DDS_WRITE_TS;
-  void * DDS_WRITECDR;
+// humble : dds_write, dds_writecdr
+// jazzy : dds_write, dds_write_ts
+void * DDS_WRITE;
+void * DDS_WRITE_TS;
+void * DDS_WRITECDR;
 }  // namespace CYCLONEDDS
 
 // For FastDDS
@@ -289,7 +289,7 @@ int dds_write_ts(void * wr, void * data, int64_t tstamp)  // NOLINT
   if (CYCLONEDDS::DDS_WRITE_TS == nullptr) {
     update_dds_function_addr();
   }
-  
+
   int dds_return = 0;
   if (CYCLONEDDS::DDS_WRITE_TS != nullptr) {
     dds_return = ((functionT)CYCLONEDDS::DDS_WRITE_TS)(wr, data, tstamp);

--- a/CARET_trace/src/hooked_trace_points.cpp
+++ b/CARET_trace/src/hooked_trace_points.cpp
@@ -59,8 +59,11 @@ rmw_ret_t rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t
 // cspell: ignore WRITECDR
 namespace CYCLONEDDS
 {
-void * DDS_WRITE_IMPL;
-void * DDS_WRITECDR_IMPL;
+  // humble : dds_write, dds_writecdr
+  // jazzy : dds_write, dds_write_ts
+  void * DDS_WRITE;
+  void * DDS_WRITE_TS;
+  void * DDS_WRITECDR;
 }  // namespace CYCLONEDDS
 
 // For FastDDS
@@ -199,7 +202,6 @@ void update_dds_function_addr()
     env_var = STRINGIFY(DEFAULT_RMW_IMPLEMENTATION);
   }
 
-  // ref. rosidl_typesupport/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
   std::string library_name;
   try {
     library_name = rcpputils::get_platform_library_name(env_var);
@@ -228,20 +230,23 @@ void update_dds_function_addr()
     }
 
     data_container.store_rmw_implementation(env_var.c_str(), now);
-
     record(env_var.c_str(), now);
   }
 
   if (env_var == "rmw_fastrtps_cpp") {
     // clang-format off
-    // // rmw_fastrtps_shared_cpp::TypeSupport::serialize(void*,
-    // eprosima::fastrtps::rtps::SerializedPayload_t*)  // NOLINT
     FASTDDS::SET_FRAGMENTS = lib->get_symbol(
       "_ZN8eprosima8fastrtps4rtps13WriterHistory13set_fragmentsEPNS1_13CacheChange_tE");  // NOLINT
     // clang-format on
   } else if (env_var == "rmw_cyclonedds_cpp") {
-    CYCLONEDDS::DDS_WRITE_IMPL = lib->get_symbol("dds_write_impl");
-    CYCLONEDDS::DDS_WRITECDR_IMPL = lib->get_symbol("dds_writecdr_impl");
+    CYCLONEDDS::DDS_WRITE = lib->get_symbol("dds_write");
+    CYCLONEDDS::DDS_WRITE_TS = lib->get_symbol("dds_write_ts");
+
+    if (!is_jazzy_or_later()) {
+      CYCLONEDDS::DDS_WRITECDR = lib->get_symbol("dds_writecdr");
+    } else {
+      CYCLONEDDS::DDS_WRITECDR = nullptr;
+    }
   }
 }
 
@@ -249,16 +254,47 @@ void update_dds_function_addr()
 
 // for cyclonedds
 // bind : &ros_message -> source_timestamp
-int dds_write_impl(void * wr, void * data, long tstamp, int action)  // NOLINT
+int dds_write(void * wr, void * data)  // NOLINT
 {
   static auto & context = Singleton<Context>::get_instance();
-  using functionT = int (*)(void *, void *, long, int);  // NOLINT
+  static auto & clock = context.get_clock();
+  using functionT = int (*)(void *, void *, int64_t);  // NOLINT
 
-  // clang-format on
-  if (CYCLONEDDS::DDS_WRITE_IMPL == nullptr) {
+  if (CYCLONEDDS::DDS_WRITE_TS == nullptr) {
     update_dds_function_addr();
   }
-  int dds_return = ((functionT)CYCLONEDDS::DDS_WRITE_IMPL)(wr, data, tstamp, action);
+
+  int64_t tstamp = clock.now();
+
+  // Call dds_write_ts instead of dds_write to get the timestamp for recording.
+  int dds_return = 0;
+  if (CYCLONEDDS::DDS_WRITE_TS != nullptr) {
+    dds_return = ((functionT)CYCLONEDDS::DDS_WRITE_TS)(wr, data, tstamp);
+  }
+
+  if (context.is_recording_allowed() && trace_filter_is_rcl_publish_recorded) {
+    tracepoint(TRACEPOINT_PROVIDER, dds_bind_addr_to_stamp, data, tstamp);
+#ifdef DEBUG_OUTPUT
+    std::cerr << "dds_bind_addr_to_stamp," << data << "," << tstamp << std::endl;
+#endif
+  }
+  return dds_return;
+}
+
+int dds_write_ts(void * wr, void * data, int64_t tstamp)  // NOLINT
+{
+  static auto & context = Singleton<Context>::get_instance();
+  using functionT = int (*)(void *, void *, int64_t);  // NOLINT
+
+  if (CYCLONEDDS::DDS_WRITE_TS == nullptr) {
+    update_dds_function_addr();
+  }
+  
+  // use rmw timestamp
+  int dds_return = 0;
+  if (CYCLONEDDS::DDS_WRITE_TS != nullptr) {
+    dds_return = ((functionT)CYCLONEDDS::DDS_WRITE_TS)(wr, data, tstamp);
+  }
 
   if (!context.get_controller().is_allowed_process()) {
     return dds_return;
@@ -273,30 +309,32 @@ int dds_write_impl(void * wr, void * data, long tstamp, int action)  // NOLINT
   return dds_return;
 }
 
-// for cyclonedds
-// bind : &ros_message -> source_timestamp
-// cspell: ignore ddsi, serdata, dinp
-int dds_writecdr_impl(void * wr, void * xp, struct ddsi_serdata * dinp, bool flush)  // NOLINT
+// for cyclonedds: humble / iron
+int dds_writecdr(void * writer, struct ddsi_serdata * serdata) // NOLINT
 {
   static auto & context = Singleton<Context>::get_instance();
-  using functionT = int (*)(void *, void *, struct ddsi_serdata *, bool);  // NOLINT
+  using functionT = int (*)(void *, struct ddsi_serdata *);  // NOLINT
 
-  // clang-format on
-  if (CYCLONEDDS::DDS_WRITECDR_IMPL == nullptr) {
+  if (CYCLONEDDS::DDS_WRITECDR == nullptr) {
     update_dds_function_addr();
   }
-  int dds_return = ((functionT)CYCLONEDDS::DDS_WRITECDR_IMPL)(wr, xp, dinp, flush);
 
-  if (!context.get_controller().is_allowed_process()) {
-    return dds_return;
+  // except jazzy
+  if (CYCLONEDDS::DDS_WRITECDR == nullptr || !context.get_controller().is_allowed_process()) {
+    if (CYCLONEDDS::DDS_WRITECDR != nullptr) {
+      return ((functionT)CYCLONEDDS::DDS_WRITECDR)(writer, serdata);
+    }
+    return 0;
   }
+
+  int dds_return = ((functionT)CYCLONEDDS::DDS_WRITECDR)(writer, serdata);
 
   bool filter = is_jazzy_or_later() ? trace_filter_is_rcl_publish_recorded : true;
   if (context.is_recording_allowed() && filter) {
     tracepoint(
-      TRACEPOINT_PROVIDER, dds_bind_addr_to_stamp, serialized_message_addr, dinp->timestamp.v);
+      TRACEPOINT_PROVIDER, dds_bind_addr_to_stamp, serialized_message_addr, serdata->timestamp.v);
 #ifdef DEBUG_OUTPUT
-    std::cerr << "dds_bind_addr_to_stamp," << serialized_message_addr << "," << dinp->timestamp.v
+    std::cerr << "dds_bind_addr_to_stamp," << serialized_message_addr << "," << serdata->timestamp.v
               << std::endl;
 #endif
   }


### PR DESCRIPTION
## Description

This PR refactors the CycloneDDS hooking mechanism to fully eliminate source bundling. By leveraging upstream public APIs, it ensures a clean build environment for ROS 2 Jazzy and newer, while maintaining robust tracing capabilities for Humble and Iron.

**Transition to Public APIs**: Removed the dependency on private `dds_write_impl` and transitioned to hooking public `dds_write`, `dds_writecdr` and `dds_write_ts`.

- **Jazzy**: Confirmed that tracing and visualization work perfectly for both regular and generic communications.
- **Humble**: Confirmed successful visualization and accurate latency calculation across all standard communication paths.

- This PR must be merged and verified in conjunction with the corresponding `caret` PR [(https://github.com/tier4/caret/pull/234)](https://github.com/tier4/caret/pull/234).

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-126](https://tier4.atlassian.net/browse/SYSPERF-126)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
