### PR TITLE
add ros2trace to package.xml

### DIFF
--- a/CARET_trace/package.xml
+++ b/CARET_trace/package.xml
@@ -21,6 +21,7 @@
   <depend>rmw_fastrtps_shared_cpp</depend>
   <depend>rmw_implementation</depend>
   <depend>std_msgs</depend>
+  <depend>tracetools</depend>
   <depend>uuid</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

To resolve the ros_tracing dependency, add tracetools to the dependencies section of package.xml

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-131](https://tier4.atlassian.net/browse/SYSPERF-131)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
